### PR TITLE
[Bug Fix] Input filter by project name field is not reset if user didn't tap `enter key` and then reset Filter.

### DIFF
--- a/fe/src/pages/index.js
+++ b/fe/src/pages/index.js
@@ -28,6 +28,8 @@ const Home = () => {
 
   const { provider, searchProvider } = Router.query
 
+  const [nameFilter, setNameFilter] = useState(searchProvider || '')
+
   const fetchProjects = () => {
     const params = {
       filterProvider: provider,
@@ -72,12 +74,19 @@ const Home = () => {
     }
   }
 
-  const resetFilters = () => Router.push('/')
+  const resetFilters = () => {
+    Router.push('/')
+    setNameFilter('')
+  }
 
   useEffect(() => {
     setProjects([])
     fetchProjects()
   }, [provider, searchProvider])
+
+  useEffect(() => {
+    if (searchProvider) setNameFilter(searchProvider)
+  }, [searchProvider])
 
   return (
     <Container>
@@ -102,7 +111,10 @@ const Home = () => {
             <TextInput
               placeholder='Project Name'
               label='Filter by name'
-              defaultValue={searchProvider}
+              value={nameFilter}
+              onChange={(event) => {
+                setNameFilter(event.target.value)
+              }}
               onKeyPress={providerOnSearch}
             />
             <Select

--- a/fe/src/pages/index.js
+++ b/fe/src/pages/index.js
@@ -12,6 +12,7 @@ import {
   Text,
   TextInput,
 } from '@mantine/core'
+import { useDebouncedValue } from '@mantine/hooks'
 
 import Navbar from '../components/molecules/Navbar'
 import HomePageDeleteModal from '../components/organisms/HomePageDeleteModal'
@@ -28,7 +29,9 @@ const Home = () => {
 
   const { provider, searchProvider } = Router.query
 
-  const [nameFilter, setNameFilter] = useState(searchProvider || '')
+  const [nameFilter, setNameFilter] = useState('')
+  const [debouncedNameFilter] = useDebouncedValue(nameFilter, 500)
+  const [userChangedNameFilter, setUserChangedNameFilter] = useState(false)
 
   const fetchProjects = () => {
     const params = {
@@ -63,16 +66,21 @@ const Home = () => {
     })
   }
 
-  const providerOnSearch = (event) => {
-    if (event.key === 'Enter') {
-      const value = event.target.value
+  useEffect(() => {
+    if (userChangedNameFilter) {
+      if (Router.query.searchProvider) {
+        delete Router.query.searchProvider
+      }
 
       Router.push({
         pathname: '/',
-        query: { ...Router.query, searchProvider: value },
+        query: {
+          ...Router.query,
+          ...(debouncedNameFilter && { searchProvider: debouncedNameFilter }),
+        },
       })
     }
-  }
+  }, [debouncedNameFilter])
 
   const resetFilters = () => {
     Router.push('/')
@@ -114,8 +122,8 @@ const Home = () => {
               value={nameFilter}
               onChange={(event) => {
                 setNameFilter(event.target.value)
+                setUserChangedNameFilter(true)
               }}
-              onKeyPress={providerOnSearch}
             />
             <Select
               label='Filter by provider'


### PR DESCRIPTION
# Issue:
https://app.asana.com/0/1202107027507930/1202310722230115/f

# Definition of Done
- [ ] Input field for the Search by  project name must be reset if user reset filter. Even without hitting the ENTER Key

### Note:
Test View Points : 
- Reset all input fields if push reset filter button
- Display default List of project and provider
- Can Filter by project name and Provider

# Commands to run
- `docker-compose exec bff yarn run test -- index`

# Route
`/`

# Attachments
none
