### PR TITLE
[Bug Fix] Unable to display Project list again if user open the project details and then go back to home page again.

### DIFF
--- a/backlog/controllers/ProjectController.ts
+++ b/backlog/controllers/ProjectController.ts
@@ -36,7 +36,7 @@ export default class ProjectController {
 
   async getProjectById(req: Request, res: Response) {
     if (/[a-zA-z]/.test(req.params.id)) {
-      res.send({
+      res.status(400).json({
         message: 'Invalid ID'
       })
     } else {
@@ -46,7 +46,8 @@ export default class ProjectController {
         }
       })
 
-      res.send(!result ? { message: 'No Data Found' } : result)
+      if (!result) res.status(404).json({ message: 'No Data Found' })
+      else res.send(result)
     }
   }
 

--- a/backlog/test/controllers/ProjectController.test.ts
+++ b/backlog/test/controllers/ProjectController.test.ts
@@ -94,19 +94,36 @@ describe('When getProjectById', () => {
       })
     })
 
-    it('should respond "Invalid ID" as validation error if id is string', async () => {
-      req.params = { id: 'test' }
-      await Controller.getProjectById(req, res)
-      const data = res._getData()
-      expect(data).toHaveProperty('message', 'Invalid ID')
+    describe('when ID is invalid', () => {
+      beforeEach(async () => {
+        req.params = { id: 'test' }
+        await Controller.getProjectById(req, res)
+      })
+
+      it('should return status of 400', () => {
+        expect(res.statusCode).toBe(400)
+      })
+
+      it('should respond "Invalid ID" as validation error', () => {
+        const data = res._getJSONData()
+        expect(data).toHaveProperty('message', 'Invalid ID')
+      })
     })
 
-    it('should respond "No Data Found" if no data in DB', async () => {
-      /* @ts-ignore */
-      req.params = { id: 99999999999999 }
-      await Controller.getProjectById(req, res)
-      const data = res._getData()
-      expect(data).toHaveProperty('message', 'No Data Found')
+    describe('when project with provided ID does not exist', () => {
+      beforeEach(async () => {
+        req.params = { id: 99999999999999 }
+        await Controller.getProjectById(req, res)
+      })
+
+      it('should return status of 404', () => {
+        expect(res.statusCode).toBe(404)
+      })
+
+      it('should respond "No Data Found" as validation error', () => {
+        const data = res._getJSONData()
+        expect(data).toHaveProperty('message', 'No Data Found')
+      })
     })
 
     it('should responed project object', async () => {

--- a/bff/src/services/BacklogService.ts
+++ b/bff/src/services/BacklogService.ts
@@ -25,9 +25,13 @@ export default class BacklogService {
     await axios({
       url: `${URL}/projects/${id}`,
       method: 'get'
-    }).then((response: AxiosResponse) => {
-      data = response.data
     })
+      .then((response: AxiosResponse) => {
+        data = response.data
+      })
+      .catch((error) => {
+        data = { errors: error.response.data, status: error.response.status }
+      })
 
     return data
   }
@@ -76,9 +80,20 @@ export default class BacklogService {
       .then((response: AxiosResponse) => {
         return response.data
       })
-      .catch((error: AxiosError) => {
-        return error.message
+      .catch((error) => {
+        return { errors: error.response.data, status: error.response.status }
       })
+  }
+
+  // BACKLOG ENDPOINT
+
+  static async backlogProjects(payload: any) {
+    return await axios({
+      baseURL: URL,
+      url: '/backlog/projects',
+      method: 'get',
+      params: payload
+    })
   }
 
   // WILL CONNECT TO BACKLOG API (not microservice)
@@ -115,17 +130,6 @@ export default class BacklogService {
     return data
   }
 
-  // BACKLOG ENDPOINT
-
-  static async backlogProjects(payload: any) {
-    return await axios({
-      baseURL: URL,
-      url: '/backlog/projects',
-      method: 'get',
-      params: payload
-    })
-  }
-
   async getActiveSprintData(
     space_key: string,
     key: string,
@@ -139,9 +143,13 @@ export default class BacklogService {
       url: '/issues',
       method: 'get',
       params: { apiKey: key, 'projectId[]': project_id, 'milestoneId[]': milestone_id }
-    }).then((response: AxiosResponse) => {
-      data = response.data
     })
+      .then((response: AxiosResponse) => {
+        data = response.data
+      })
+      .catch((error) => {
+        data = { errors: error.response.data, status: error.response.status }
+      })
     return data
   }
 }

--- a/bff/src/test/routes/ProjectRoute.test.ts
+++ b/bff/src/test/routes/ProjectRoute.test.ts
@@ -9,39 +9,6 @@ app.use(express.json())
 app.use(express.urlencoded({ extended: false }))
 app.use('/', ProjectRoute)
 
-describe('Project Route Test Suite', () => {
-  test('Test #1: getProjectById - if ID exist in the database', async () => {
-    const projects: any = await request(app).get('/')
-    const data = JSON.parse(projects.text)
-
-    if (!data.length) {
-      expect(data).toStrictEqual([])
-    } else {
-      const result = await request(app).get(`/${data[0].id}`).send({ service: 'backlog' })
-      expect(JSON.parse(result.text)).toHaveProperty('id')
-    }
-  })
-
-  test('Test #2: getProjectById - if ID does not exist in the database', async () => {
-    const result = await request(app).get('/111111').send({ service: 'backlog' })
-    const data = JSON.parse(result.text)
-    expect(data).toHaveProperty('message', 'No Data Found')
-  })
-
-  test('Test #3: getProjectById - invalid ID, letters are not valid', async () => {
-    const result = await request(app).get('/test').send({ service: 'backlog' })
-    const data = JSON.parse(result.text)
-    expect(data).toHaveProperty('message', 'Invalid ID')
-  })
-
-  test('Test #4: getProjects - either array of objects or empty array', async () => {
-    const projects = await request(app).get('/')
-    const data = JSON.parse(projects.text)
-    if (!data.length) expect(data).toStrictEqual([])
-    else expect(data[0]).toHaveProperty('id')
-  })
-})
-
 describe('When deleting through /projects/:id route', () => {
   let result: request.Response
 

--- a/bff/src/test/services/BacklogService.test.ts
+++ b/bff/src/test/services/BacklogService.test.ts
@@ -7,34 +7,72 @@ import projectTestData from '../constants/projectTestData.json'
 
 const backlogService = new BacklogService()
 
-describe('Backlog Service Test Suite', () => {
-  test('Test #1: getProjectById - if ID exist in the database', async () => {
-    const projects: any = await backlogService.getProjects()
+describe('When using getProjectById() function', () => {
+  let project: any
 
-    if (!projects.length) {
-      expect(projects).toStrictEqual([])
-    } else {
-      const project: any = await backlogService.getProjectById(`/${projects[0].id}`)
+  describe('if ID exist in the database', () => {
+    beforeEach(async () => {
+      server.use(
+        rest.get('*/api/projects/*', (req, res, ctx) => {
+          return res(ctx.json(projectTestData.sampleProject))
+        })
+      )
+
+      project = await backlogService.getProjectById('/1')
+    })
+
+    it('should return expected body', () => {
       expect(project).toHaveProperty('id')
-    }
+    })
   })
 
-  test('Test #2: getProjectById - if ID does not exist in the database', async () => {
-    const project: any = await backlogService.getProjectById('/111111')
-    expect(project).toHaveProperty('message', 'No Data Found')
+  describe('if ID does not exist in the database', () => {
+    beforeEach(async () => {
+      server.use(
+        rest.get('*/api/projects/*', (req, res, ctx) => {
+          return res(ctx.status(404), ctx.json({ message: 'No Data Found' }))
+        })
+      )
+
+      project = await backlogService.getProjectById('/1')
+    })
+
+    it('should return status of 404', () => {
+      expect(project.status).toBe(404)
+    })
+
+    it("should have 'No Data Found' as error message", () => {
+      expect(project.errors).toHaveProperty('message', 'No Data Found')
+    })
   })
 
-  test('Test #3: getProjectById - invalid ID, letters are not valid', async () => {
-    const project: any = await backlogService.getProjectById('/test')
-    expect(project).toHaveProperty('message', 'Invalid ID')
-  })
+  describe('if invalid ID, non numeric is invalid', () => {
+    beforeEach(async () => {
+      server.use(
+        rest.get('*/api/projects/*', (req, res, ctx) => {
+          return res(ctx.status(400), ctx.json({ message: 'Invalid ID' }))
+        })
+      )
 
+      project = await backlogService.getProjectById('/1')
+    })
+
+    it('should return status of 400', () => {
+      expect(project.status).toBe(400)
+    })
+
+    it("should have 'No Data Found' as error message", () => {
+      expect(project.errors).toHaveProperty('message', 'Invalid ID')
+    })
+  })
+})
+
+describe('Backlog Service Test Suite', () => {
   test('Test #4: getProjects - fetch all projects', async () => {
     const projects: any = await backlogService.getProjects()
     if (!projects.length) expect(projects).toStrictEqual([])
     else expect(projects[0]).toHaveProperty('id')
   })
-
 })
 
 describe('When using deleteProjectById() function', () => {
@@ -58,7 +96,7 @@ describe('When using deleteProjectById() function', () => {
     beforeEach(async () => {
       server.use(
         rest.delete('*/api/projects/*', (req, res, ctx) => {
-          return res(ctx.status(404), ctx.json({ message: "ID does not exist" }))
+          return res(ctx.status(404), ctx.json({ message: 'ID does not exist' }))
         })
       )
 
@@ -71,7 +109,7 @@ describe('When using deleteProjectById() function', () => {
 
     it('should return the error messages', () => {
       expect(project).toHaveProperty('errors')
-      expect(JSON.stringify(project.errors)).toBe(JSON.stringify({ message: "ID does not exist" }))
+      expect(JSON.stringify(project.errors)).toBe(JSON.stringify({ message: 'ID does not exist' }))
     })
   })
 
@@ -79,7 +117,7 @@ describe('When using deleteProjectById() function', () => {
     beforeEach(async () => {
       server.use(
         rest.delete('*/api/projects/*', (req, res, ctx) => {
-          return res(ctx.status(400), ctx.json({ message: "Invalid ID" }))
+          return res(ctx.status(400), ctx.json({ message: 'Invalid ID' }))
         })
       )
 
@@ -92,7 +130,7 @@ describe('When using deleteProjectById() function', () => {
 
     it('should return the error messages', () => {
       expect(project).toHaveProperty('errors')
-      expect(JSON.stringify(project.errors)).toBe(JSON.stringify({ message: "Invalid ID" }))
+      expect(JSON.stringify(project.errors)).toBe(JSON.stringify({ message: 'Invalid ID' }))
     })
   })
 })


### PR DESCRIPTION
# Issue:
https://app.asana.com/0/1202107027507930/1202310722230122/f

# Definition of Done
- [ ] Home page should still display project list after checking project details
- [ ] tests should still pass

### Note:
cause of bug:
backend services doesn't have error handling, so if the API responded with an error, the service will stop working

# Commands to run
- `docker-compose exec bff yarn run test `
- `docker-compose exec backlog yarn run test `

# Route
`/`

# Attachments
none